### PR TITLE
feat!: add NVIDIA H100 confidential GPU support for bare metal

### DIFF
--- a/ansible/reconcile-kataconfig-gpu.yaml
+++ b/ansible/reconcile-kataconfig-gpu.yaml
@@ -1,0 +1,42 @@
+---
+- name: Reconcile KataConfig for GPU RuntimeClass
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+    - name: Check for nodes with NVIDIA GPU labels
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Node
+        label_selectors:
+          - "nvidia.com/gpu.present=true"
+      register: gpu_nodes
+
+    - name: Check if kata-cc-nvidia-gpu RuntimeClass exists
+      kubernetes.core.k8s_info:
+        api_version: node.k8s.io/v1
+        kind: RuntimeClass
+        name: kata-cc-nvidia-gpu
+      register: gpu_runtimeclass
+
+    - name: Trigger KataConfig re-reconciliation
+      kubernetes.core.k8s:
+        state: patched
+        api_version: kataconfiguration.openshift.io/v1
+        kind: KataConfig
+        name: default-kata-config
+        definition:
+          metadata:
+            annotations:
+              kata-reconcile: "{{ ansible_date_time.epoch }}"
+      when:
+        - gpu_nodes.resources | length > 0
+        - gpu_runtimeclass.resources | length == 0
+
+    - name: Report status
+      ansible.builtin.debug:
+        msg: >-
+          GPU nodes: {{ gpu_nodes.resources | length }},
+          RuntimeClass exists: {{ gpu_runtimeclass.resources | length > 0 }},
+          Action: {{ 'triggered re-reconciliation' if (gpu_nodes.resources | length > 0 and gpu_runtimeclass.resources | length == 0) else 'no action needed' }}

--- a/charts/all/coco-kyverno-policies/templates/inject-coco-initdata.yaml
+++ b/charts/all/coco-kyverno-policies/templates/inject-coco-initdata.yaml
@@ -28,7 +28,7 @@ spec:
         all:
           - key: "{{ "{{" }}request.object.spec.runtimeClassName || '' {{ "}}" }}"
             operator: AnyIn
-            value: ["kata", "kata-cc", "kata-remote"]
+            value: ["kata", "kata-cc", "kata-remote", "kata-cc-nvidia-gpu"]
           - key: "{{ "{{" }}request.object.metadata.annotations.\"coco.io/initdata-configmap\" || '' {{ "}}" }}"
             operator: NotEquals
             value: ""

--- a/charts/all/coco-kyverno-policies/values.yaml
+++ b/charts/all/coco-kyverno-policies/values.yaml
@@ -1,5 +1,6 @@
 workloadNamespaces:
   - hello-openshift
   - kbs-access
+  - gpu-workload
 
 initdataSourceNamespace: imperative

--- a/charts/all/nvidia-gpu/Chart.yaml
+++ b/charts/all/nvidia-gpu/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+description: NVIDIA GPU Operator configuration for confidential containers (ClusterPolicy, IOMMU MachineConfig).
+keywords:
+- pattern
+- nvidia
+- gpu
+- confidential
+name: nvidia-gpu
+version: 0.0.1

--- a/charts/all/nvidia-gpu/templates/cluster-policy.yaml
+++ b/charts/all/nvidia-gpu/templates/cluster-policy.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.enabled }}
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+spec:
+  operator:
+    defaultRuntime: crio
+
+  sandboxWorkloads:
+    enabled: true
+    mode: kata
+    defaultWorkload: vm-passthrough
+
+  kataManager:
+    enabled: false
+
+  ccManager:
+    enabled: {{ .Values.ccManager.enabled }}
+    defaultMode: {{ .Values.ccManager.defaultMode | quote }}
+    repository: nvcr.io/nvidia/cloud-native
+    image: k8s-cc-manager
+    version: v0.1.0
+    env:
+      - name: CC_CAPABLE_DEVICE_IDS
+        value: {{ .Values.ccManager.deviceIDs | quote }}
+
+  kataSandboxDevicePlugin:
+    enabled: {{ .Values.kataSandboxDevicePlugin.enabled }}
+    repository: {{ .Values.kataSandboxDevicePlugin.repository }}
+    image: {{ .Values.kataSandboxDevicePlugin.image }}
+    version: {{ .Values.kataSandboxDevicePlugin.version | quote }}
+
+  sandboxDevicePlugin:
+    enabled: true
+
+  driver:
+    enabled: true
+
+  devicePlugin:
+    enabled: false
+
+  vfioManager:
+    enabled: true
+
+  gfd:
+    enabled: true
+
+  nfd:
+    nodefeaturerules: true
+{{- end }}

--- a/charts/all/nvidia-gpu/templates/iommu-mco.yaml
+++ b/charts/all/nvidia-gpu/templates/iommu-mco.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.iommu.enabled }}
+{{- range list "master" "worker" }}
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: {{ . }}
+  name: 100-iommu-{{ . }}
+spec:
+  kernelArguments:
+  - intel_iommu=on
+  - iommu=pt
+{{- end }}
+{{- end }}

--- a/charts/all/nvidia-gpu/values.yaml
+++ b/charts/all/nvidia-gpu/values.yaml
@@ -1,0 +1,15 @@
+enabled: true
+
+ccManager:
+  enabled: true
+  defaultMode: "on"
+  deviceIDs: "0x2331,0x2322"
+
+kataSandboxDevicePlugin:
+  enabled: true
+  repository: nvcr.io/nvidia/cloud-native
+  image: nvidia-sandbox-device-plugin
+  version: "v0.0.2"
+
+iommu:
+  enabled: true

--- a/charts/coco-supported/gpu-workload/Chart.yaml
+++ b/charts/coco-supported/gpu-workload/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+description: Sample CUDA workload for NVIDIA confidential GPU verification.
+keywords:
+- pattern
+- nvidia
+- gpu
+- workload
+- confidential
+name: gpu-workload
+version: 0.0.1

--- a/charts/coco-supported/gpu-workload/templates/gpu-vectoradd-deployment.yaml
+++ b/charts/coco-supported/gpu-workload/templates/gpu-vectoradd-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-vectoradd
+  labels:
+    app: gpu-vectoradd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gpu-vectoradd
+  template:
+    metadata:
+      labels:
+        app: gpu-vectoradd
+      annotations:
+        coco.io/initdata-configmap: initdata
+        {{- if .Values.defaultMemory }}
+        io.katacontainers.config.hypervisor.default_memory: {{ .Values.defaultMemory | quote }}
+        {{- end }}
+    spec:
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      containers:
+        - name: cuda-vectoradd
+          image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubuntu20.04
+          resources:
+            limits:
+              nvidia.com/pgpu: 1
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/charts/coco-supported/gpu-workload/values.yaml
+++ b/charts/coco-supported/gpu-workload/values.yaml
@@ -1,0 +1,6 @@
+runtimeClassName: "kata-cc-nvidia-gpu"
+
+defaultMemory: "32768"
+
+global:
+  clusterPlatform: ""

--- a/values-baremetal.yaml
+++ b/values-baremetal.yaml
@@ -20,6 +20,8 @@ clusterGroup:
   - openshift-nfd
   - baremetal
   - intel-dcap
+  - nvidia-gpu-operator
+  - gpu-workload
   - kyverno
 
   subscriptions:
@@ -60,6 +62,13 @@ clusterGroup:
       name: nfd
       namespace: openshift-nfd
       channel: stable
+    gpu-operator:
+      name: gpu-operator-certified
+      namespace: nvidia-gpu-operator
+      source: certified-operators
+      channel: v26.3
+      installPlanApproval: Manual
+      csv: gpu-operator-certified.v26.3.0
     intel-device-plugins:
       name: intel-device-plugins-operator
       namespace: openshift-operators
@@ -128,6 +137,8 @@ clusterGroup:
           value: passphrase
         - name: kbs.secretResources[1].key
           value: secret/data/hub/passphrase
+        - name: kbs.gpu.enabled
+          value: "true"
 
     storage:
       name: storage
@@ -168,6 +179,21 @@ clusterGroup:
           value: vault-backend
         - name: secretStore.kind
           value: ClusterSecretStore
+
+    nvidia-gpu:
+      name: nvidia-gpu
+      namespace: nvidia-gpu-operator
+      project: hub
+      path: charts/all/nvidia-gpu
+
+    gpu-workload:
+      name: gpu-workload
+      namespace: gpu-workload
+      project: workloads
+      path: charts/coco-supported/gpu-workload
+      syncPolicy:
+        automated:
+          prune: true
 
     sandbox-policies:
       name: sandbox-policies
@@ -259,6 +285,10 @@ clusterGroup:
       playbook: ansible/init-data-gzipper.yaml
       verbosity: -vvv
       timeout: 3600
+    - name: reconcile-kataconfig-gpu
+      playbook: ansible/reconcile-kataconfig-gpu.yaml
+      verbosity: -vvv
+      timeout: 600
     # Required for tech preview only.
     # - name: detect-runtime-class
     #   playbook: ansible/detect-runtime-class.yaml


### PR DESCRIPTION
## Summary

- Adds NVIDIA H100/H200 confidential GPU support for bare metal CoCo deployments
- Fixes three documented gaps in Red Hat OSC 1.12 docs (NVIDIA-notes.md): GPU Operator pinned to v26.3.0, `kataSandboxDevicePlugin` included in ClusterPolicy, KataConfig re-reconciliation via imperative job
- New `charts/all/nvidia-gpu/` chart: ClusterPolicy CR with CC manager, kata sandbox device plugin, VFIO manager, and IOMMU MachineConfig
- New `charts/coco-supported/gpu-workload/` chart: CUDA vectorAdd sample Deployment on `kata-cc-nvidia-gpu` runtime class
- Extends Kyverno initdata injection to match `kata-cc-nvidia-gpu` and propagate initdata to `gpu-workload` namespace
- Adds `kbs.gpu.enabled` trustee override for GPU attestation policy (requires coordinated trustee-chart changes on `feature/baremetal-attestation`)

## Test plan

- [ ] `./pattern.sh make preview-all` renders without errors
- [ ] `./pattern.sh make validate-schema` passes
- [ ] GPU Operator v26.3.0 installs via pinned subscription
- [ ] ClusterPolicy creates `nvidia-kata-sandbox-device-plugin-daemonset` and advertises `nvidia.com/pgpu`
- [ ] Imperative job triggers KataConfig re-reconciliation, creating `kata-cc-nvidia-gpu` RuntimeClass
- [ ] `gpu-vectoradd` Deployment schedules and logs `Test PASSED`
- [ ] Kyverno injects `cc_init_data` annotation into GPU workload pods
- [ ] Existing TDX/SEV-SNP workloads (hello-openshift, kbs-access) remain functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)