### PR TITLE
feat: update operator CSV pins and trustee chartVersion for OSC 1.13 / Trustee 1.2

### DIFF
--- a/values-azure.yaml
+++ b/values-azure.yaml
@@ -36,13 +36,13 @@ clusterGroup:
       namespace: openshift-sandboxed-containers-operator
       channel: stable
       installPlanApproval: Manual
-      csv: sandboxed-containers-operator.v1.12.0
+      csv: sandboxed-containers-operator.v1.13.0
     trustee:
       name: trustee-operator
       namespace: trustee-operator-system
       channel: stable
       installPlanApproval: Manual
-      csv: trustee-operator.v1.1.0
+      csv: trustee-operator.v1.2.0
     cert-manager:
       name: openshift-cert-manager-operator
       namespace: cert-manager-operator
@@ -87,7 +87,7 @@ clusterGroup:
       namespace: trustee-operator-system
       project: trustee
       chart: trustee
-      chartVersion: 0.8.*
+      chartVersion: 0.9.*
       extraValueFiles:
         - '/overrides/values-trustee.yaml'
       overrides:

--- a/values-baremetal.yaml
+++ b/values-baremetal.yaml
@@ -41,7 +41,7 @@ clusterGroup:
       namespace: openshift-sandboxed-containers-operator
       channel: stable
       installPlanApproval: Manual
-      csv: sandboxed-containers-operator.v1.12.0
+      csv: sandboxed-containers-operator.v1.13.0
       annotations:
         argocd.argoproj.io/sync-wave: "10"
     trustee:
@@ -49,7 +49,7 @@ clusterGroup:
       namespace: trustee-operator-system
       channel: stable
       installPlanApproval: Manual
-      csv: trustee-operator.v1.1.0
+      csv: trustee-operator.v1.2.0
       annotations:
         argocd.argoproj.io/sync-wave: "10"
     cert-manager:
@@ -164,7 +164,8 @@ clusterGroup:
       annotations:
         argocd.argoproj.io/sync-wave: "20"
       chart: trustee
-      chartVersion: 0.8.*
+      chartVersion: 0.9.*
+      targetRevision: dev/osc-1.13-upgrade
       extraValueFiles:
         - '/overrides/values-trustee.yaml'
       overrides:

--- a/values-trusted-hub.yaml
+++ b/values-trusted-hub.yaml
@@ -31,7 +31,7 @@ clusterGroup:
       namespace: trustee-operator-system
       channel: stable
       installPlanApproval: Manual
-      csv: trustee-operator.v1.1.0
+      csv: trustee-operator.v1.2.0
     cert-manager:
       name: openshift-cert-manager-operator
       namespace: cert-manager-operator
@@ -77,7 +77,7 @@ clusterGroup:
       namespace: trustee-operator-system
       project: trustee
       chart: trustee
-      chartVersion: 0.8.*
+      chartVersion: 0.9.*
       extraValueFiles:
         - '/overrides/values-trustee.yaml'
       overrides:


### PR DESCRIPTION
## Summary

Update coco-pattern topology values files to reference Trustee 1.2.0 / OSC 1.13.0 operators and trustee-chart v0.9.x.

### Operator Subscription CSV Pins
- trustee-operator: v1.1.0 → v1.2.0 (all topology files)
- sandboxed-containers-operator: v1.12.0 → v1.13.0 (all topology files)

### Trustee Chart Version
- chartVersion: 0.8.* → 0.9.* (baremetal, azure, trusted-hub)
- targetRevision: dev/osc-1.13-upgrade added to baremetal trustee app for branch-based testing

### Files Changed
- values-baremetal.yaml
- values-azure.yaml
- values-trusted-hub.yaml

### What's NOT Changed (by design)
- sandboxed-containers-chart chartVersion stays at 0.2.* (D-10: zero changes needed)
- sandboxed-policies-chart chartVersion stays at 0.2.* (D-11: zero changes needed)
- Workload charts unchanged (D-12: CDH URI format is version-independent)
- Initdata templates confirmed version-insensitive (D-08 audit complete)

### Companion PR
- butler54/trustee-chart#3 — trustee-chart v0.9.0 with Trustee 1.2 config format

## Test plan

- [ ] Deploy on fresh OCP cluster with OSC 1.13 / Trustee 1.2 operators (Phase 15)
- [ ] Verify ArgoCD resolves trustee-chart from dev/osc-1.13-upgrade branch
- [ ] Verify operator subscriptions install correct CSV versions